### PR TITLE
Define default SessionBuilder class in the config

### DIFF
--- a/sources/lib/DependencyInjection/Configuration.php
+++ b/sources/lib/DependencyInjection/Configuration.php
@@ -42,7 +42,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('array')
                         ->children()
                             ->scalarNode('dsn')->isRequired()->end()
-                            ->scalarNode('class:session_builder')->end()
+                            ->scalarNode('class:session_builder')->defaultValue('\PommProject\ModelManager\SessionBuilder')->end()
                             ->scalarNode('pomm:default')->end()
                         ->end()
                     ->end()


### PR DESCRIPTION
Fix #38

Same as the Zend Module. https://github.com/pomm-project/PommModule/blob/183d0c17bcb16e7c7b25ac0fdef27f16e6dabf92/src/Service/AbstractServiceFactory.php#L44