### PR TITLE
Shutdown using Pomm::shutdown() method

### DIFF
--- a/sources/lib/PommBundle.php
+++ b/sources/lib/PommBundle.php
@@ -53,6 +53,6 @@ class PommBundle extends Bundle
      */
     public function shutdown()
     {
-        $pomm = $this->container->get('pomm')->shutdown();
+        $this->container->get('pomm')->shutdown();
     }
 }

--- a/sources/lib/PommBundle.php
+++ b/sources/lib/PommBundle.php
@@ -53,14 +53,6 @@ class PommBundle extends Bundle
      */
     public function shutdown()
     {
-        $pomm = $this->container->get('pomm');
-        $configurations = $this->container->getParameter('pomm.configuration');
-
-        foreach ($configurations as $name => $configuration) {
-            if ($pomm->hasSession($name)) {
-                $pomm[$name]->getConnection()
-                    ->close();
-            }
-        }
+        $pomm = $this->container->get('pomm')->shutdown();
     }
 }


### PR DESCRIPTION
Use Foundation's `close_session` branch to test this patch.