### PR TITLE
add tag listener for datacollector

### DIFF
--- a/sources/lib/DataCollector/DatabaseDataCollector.php
+++ b/sources/lib/DataCollector/DatabaseDataCollector.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * This file is part of Pomm's SymfonyBundle package.
+ *
+ * (c) 2014 Grégoire HUBERT <hubert.greg@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PommProject\PommBundle\DataCollector;
+
+use PommProject\SymfonyBridge\DatabaseDataCollector as BaseDatabaseDataCollector;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Data collector for the database profiler.
+ *
+ * @package PommSymfonyBridge
+ * @copyright 2014 Grégoire HUBERT
+ * @author Jérôme MACIAS
+ * @author Grégoire HUBERT
+ * @license X11 {@link http://opensource.org/licenses/mit-license.php}
+ * @see DataCollector
+ */
+class DatabaseDataCollector extends BaseDatabaseDataCollector
+{
+    public function onKernelController(Event $event)
+    {
+        return;
+    }
+}

--- a/sources/lib/Resources/config/services/profiler.yml
+++ b/sources/lib/Resources/config/services/profiler.yml
@@ -5,9 +5,10 @@ services:
         tags:
             - { name: data_collector, template: '@Pomm/Collector/time.html.twig', id: 'time'}
     pomm.data_collector:
-        class: 'PommProject\SymfonyBridge\DatabaseDataCollector'
+        class: 'PommProject\PommBundle\DataCollector\DatabaseDataCollector'
         arguments: ['@pomm', '@?debug.stopwatch']
         tags:
+            - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
             - { name: data_collector, template: '@Pomm/Profiler/db.html.twig', id: 'pomm'}
     pomm.twig_extension:
         class: 'PommProject\PommBundle\Twig\Extension\ProfilerExtension'


### PR DESCRIPTION
In sf3.0, profiler is started after controller. 

Datacollector is init after create session for query. For init datacollector before I add a tag listener on kernel.controller.

I can't add symfony3 for test because behat/mink don't support for moment.