### PR TITLE
Register twig extension only if profiler is available

### DIFF
--- a/sources/lib/DependencyInjection/Compiler/ProfilerPass.php
+++ b/sources/lib/DependencyInjection/Compiler/ProfilerPass.php
@@ -17,5 +17,15 @@ class ProfilerPass implements DI\Compiler\CompilerPassInterface
             [new DI\Reference('router'), new DI\Reference('profiler'), new DI\Reference('twig'), new DI\Reference('pomm')]
         );
         $container->setDefinition('pomm.controller.profiler', $definition);
+
+        $definition = new DI\Definition(
+            "PommProject\\PommBundle\\Twig\\Extension\\ProfilerExtension",
+            [new DI\Reference('Twig.loader')]
+        );
+        //we run after the twig tags are collected so we need to manually do what twig compiler pass does
+        $twig = $container->getDefinition('twig');
+        $twig->addMethodCall('addExtension', [new DI\Reference('pomm.twig_extension')]);
+
+        $container->setDefinition('pomm.twig_extension', $definition);
     }
 }

--- a/sources/lib/Resources/config/services/profiler.yml
+++ b/sources/lib/Resources/config/services/profiler.yml
@@ -9,11 +9,6 @@ services:
         arguments: [null,'@?debug.stopwatch']
         tags:
             - { name: data_collector, template: '@Pomm/Profiler/db.html.twig', id: 'pomm'}
-    pomm.twig_extension:
-        class: 'PommProject\PommBundle\Twig\Extension\ProfilerExtension'
-        arguments: ['@Twig.loader']
-        tags:
-            - { name: twig.extension }
     pomm.data_collector.configurator:
         class: 'PommProject\PommBundle\Configurator\DatabaseCollectorConfigurator'
         arguments: ['@?pomm.data_collector']


### PR DESCRIPTION
This will register the TwigExtension only if profiler is available.
This means that in the config the templating can be set to false e.g.

```yaml
framework:
    templating: false
```
