### PR TITLE
Rename connection to session in ParamConverter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ before_install:
     - psql -c 'CREATE DATABASE pomm_test' -U postgres -h 127.0.0.1 postgres
     - psql -c 'CREATE TABLE config (name character varying(25) PRIMARY KEY, value character varying(25))' -U postgres -h 127.0.0.1 pomm_test
     - psql -c "INSERT INTO config VALUES ('test', 'value')" -U postgres -h 127.0.0.1 pomm_test
+    - psql -c 'CREATE DATABASE pomm_test_2' -U postgres -h 127.0.0.1 postgres
+    - psql -c 'CREATE TABLE config (name character varying(25) PRIMARY KEY, value character varying(25))' -U postgres -h 127.0.0.1 pomm_test_2
+    - psql -c "INSERT INTO config VALUES ('test', 'value_db2')" -U postgres -h 127.0.0.1 pomm_test_2
 
     - php -S localhost:8080 -t web &> /dev/null &
     - ln -fs parameters.yml.dist app/config/parameters.yml

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can specify witch connexion use in the option:
 ```php
 
 /**
- * @ParamConverter("student", options={"connection": "my_db2"})
+ * @ParamConverter("student", options={"session": "my_db2"})
  */
 public function getAction(Student $student)
 ```

--- a/sources/lib/Request/ParamConverter/EntityParamConverter.php
+++ b/sources/lib/Request/ParamConverter/EntityParamConverter.php
@@ -56,7 +56,7 @@ class EntityParamConverter implements ParamConverterInterface
             'model' => $configuration->getClass() . 'Model',
         ], $configuration->getOptions());
 
-        if (isset($options['connection'])) {
+        if (isset($options['session'])) {
             $options['session'] = $this->pomm[$options['session']];
         }
         else {

--- a/tests/app/autoload.php
+++ b/tests/app/autoload.php
@@ -1,0 +1,11 @@
+<?php
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Composer\Autoload\ClassLoader;
+
+/** @var ClassLoader $loader */
+$loader = require __DIR__.'/../vendor/autoload.php';
+
+AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+
+return $loader;

--- a/tests/app/config/config.yml
+++ b/tests/app/config/config.yml
@@ -38,7 +38,8 @@ pomm:
             dsn: "pgsql://%database_user%:%database_password%@%database_host%:%database_port%/%database_name%"
             class:session_builder: '\PommProject\ModelManager\SessionBuilder'
             pomm:default: true
-        #my_db2:
-        #    dsn: 'pgsql://user:pass@host:port/db_name2'
+        my_db2:
+            dsn: "pgsql://%database_user%:%database_password%@%database_host%:%database_port%/%database_name%_2"
+            class:session_builder: '\PommProject\ModelManager\SessionBuilder'
     logger:
         service: '@logger'

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -4,10 +4,10 @@
         "symfony/monolog-bundle": "~3.0",
         "twig/extensions": "~1.0",
         "sensio/framework-extra-bundle": "~3.0,>=3.0.2",
-        "pomm-project/cli": "dev-master",
-        "pomm-project/foundation": "dev-master",
+        "pomm-project/cli": "~2.0",
+        "pomm-project/foundation": "~2.0",
+        "pomm-project/model-manager": "~2.0",
         "pomm-project/pomm-bundle": "dev-master",
-        "pomm-project/model-manager": "dev-master",
         "pomm-project/pomm-symfony-bridge": "~2.2.1@dev"
     },
     "require-dev": {

--- a/tests/src/AppBundle/Controller/IndexController.php
+++ b/tests/src/AppBundle/Controller/IndexController.php
@@ -4,6 +4,7 @@ namespace AppBundle\Controller;
 
 use \AppBundle\Model\Config;
 use \PommProject\Foundation\Session\Session;
+use \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use \Symfony\Component\Serializer\Serializer;
 use \Symfony\Component\HttpFoundation\Response;
 use \Symfony\Component\Templating\EngineInterface;
@@ -41,6 +42,51 @@ class IndexController
     }
 
     public function getAction(Config $config = null)
+    {
+        return new Response(
+            $this->templating->render(
+                'AppBundle:Front:get.html.twig',
+                compact('config')
+            )
+        );
+    }
+
+    /**
+     * Get data with default session
+     *
+     * @ParamConverter("config", options={"model": "\AppBundle\Model\ConfigModel"})
+     */
+    public function getDefaultSessionAction(Config $config)
+    {
+        return new Response(
+            $this->templating->render(
+                'AppBundle:Front:get.html.twig',
+                compact('config')
+            )
+        );
+    }
+
+    /**
+     * Get data with session 1
+     *
+     * @ParamConverter("config", options={"session": "my_db", "model": "\AppBundle\Model\ConfigModel"})
+     */
+    public function getSessionAction(Config $config)
+    {
+        return new Response(
+            $this->templating->render(
+                'AppBundle:Front:get.html.twig',
+                compact('config')
+            )
+        );
+    }
+
+    /**
+     * Get data with session 2
+     *
+     * @ParamConverter("config", options={"session": "my_db2", "model": "\AppBundle\Model\ConfigModel"})
+     */
+    public function getSession2Action(Config $config)
     {
         return new Response(
             $this->templating->render(

--- a/tests/src/AppBundle/Resources/config/routing.yml
+++ b/tests/src/AppBundle/Resources/config/routing.yml
@@ -13,6 +13,21 @@ get:
     defaults: { _controller: index_controller:getAction }
     methods: [GET]
 
+get_session_default:
+    path: /get_session_default/{name}
+    defaults: { _controller: index_controller:getSession2Action }
+    methods: [GET]
+
+get_session:
+    path: /get_session_1/{name}
+    defaults: { _controller: index_controller:getSession2Action }
+    methods: [GET]
+
+get_session_2:
+    path: /get_session_2/{name}
+    defaults: { _controller: index_controller:getSession2Action }
+    methods: [GET]
+
 serialize:
     path: /serialize/{name}
     defaults: { _controller: index_controller:serializeAction }

--- a/tests/tests/Features/param-converter.feature
+++ b/tests/tests/Features/param-converter.feature
@@ -7,3 +7,15 @@ Feature: Entity Param Converter
     Scenario:
         When I am on "/app_dev.php/get"
         Then I should see "config => null"
+
+    Scenario:
+        When I am on "/app_dev.php/get_session_default/test"
+        Then I should see "test => value"
+
+    Scenario:
+        When I am on "/app_dev.php/get_session_1/test"
+        Then I should see "test => value"
+
+    Scenario:
+        When I am on "/app_dev.php/get_session_2/test"
+        Then I should see "test => value_db2"

--- a/tests/web/app.php
+++ b/tests/web/app.php
@@ -3,7 +3,7 @@
 use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\HttpFoundation\Request;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../app/autoload.php';
 
 $kernel = new AppKernel('prod', false);
 $kernel->loadClassCache();

--- a/tests/web/app_dev.php
+++ b/tests/web/app_dev.php
@@ -17,7 +17,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../app/autoload.php';
 
 Debug::enable();
 


### PR DESCRIPTION
There are a typo in ParamConverter.
In options, it's `connection` which is tested but it's `session` which is to use.
