### PR TITLE
Add test on the boolean property type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,11 @@ services: postgresql
 
 before_install:
     - psql -c 'CREATE DATABASE pomm_test' -U postgres -h 127.0.0.1 postgres
-    - psql -c 'CREATE TABLE config (name character varying(25) PRIMARY KEY, value character varying(25))' -U postgres -h 127.0.0.1 pomm_test
-    - psql -c "INSERT INTO config VALUES ('test', 'value')" -U postgres -h 127.0.0.1 pomm_test
+    - psql -c 'CREATE TABLE config (name character varying(25) PRIMARY KEY, value character varying(25), global boolean)' -U postgres -h 127.0.0.1 pomm_test
+    - psql -c "INSERT INTO config VALUES ('test', 'value', true)" -U postgres -h 127.0.0.1 pomm_test
     - psql -c 'CREATE DATABASE pomm_test_2' -U postgres -h 127.0.0.1 postgres
-    - psql -c 'CREATE TABLE config (name character varying(25) PRIMARY KEY, value character varying(25))' -U postgres -h 127.0.0.1 pomm_test_2
-    - psql -c "INSERT INTO config VALUES ('test', 'value_db2')" -U postgres -h 127.0.0.1 pomm_test_2
+    - psql -c 'CREATE TABLE config (name character varying(25) PRIMARY KEY, value character varying(25), global boolean)' -U postgres -h 127.0.0.1 pomm_test_2
+    - psql -c "INSERT INTO config VALUES ('test', 'value_db2', false)" -U postgres -h 127.0.0.1 pomm_test_2
 
     - php -S localhost:8080 -t tests/web &> /dev/null &
     - ln -fs parameters.yml.dist tests/app/config/parameters.yml

--- a/tests/tests/Features/property-info.feature
+++ b/tests/tests/Features/property-info.feature
@@ -9,3 +9,8 @@ Feature: Entity Param Converter
         When I am on "/app_dev.php/property/name"
         Then the response status code should be 200
         Then I should see "string"
+
+    Scenario: property type boolean
+        When I am on "/app_dev.php/property/global"
+        Then the response status code should be 200
+        Then I should see "bool"


### PR DESCRIPTION
Add tests for the property extractor, the type converter for boolean is wrong.
Yes, they miserably failed, on purpose.

See https://github.com/pomm-project/pomm-symfony-bridge/pull/40 to view the correction