### PR TITLE
Add Sensio framework extra bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "pomm-project/model-manager": "~2.0",
     "pomm-project/cli": "~2.0",
     "pomm-project/pomm-symfony-bridge": "~2.5",
-    "symfony/framework-bundle": "~2.8|~3.0|~4.0"
+    "symfony/framework-bundle": "~2.8|~3.0|~4.0",
+    "sensio/framework-extra-bundle": "^3.0|^4.0|^5.0"
   },
   "require-dev": {
     "symfony/console": "~2.6|~3.0|~4.0",
@@ -42,4 +43,3 @@
       }
   }
 }
-

--- a/tests/src/AppBundle/Controller/IndexController.php
+++ b/tests/src/AppBundle/Controller/IndexController.php
@@ -9,7 +9,7 @@ use \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use \Symfony\Component\Serializer\Serializer;
 use \Symfony\Component\HttpFoundation\Response;
 use \Symfony\Component\Templating\EngineInterface;
-use \Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use \Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 
 class IndexController
 {
@@ -23,7 +23,7 @@ class IndexController
         EngineInterface $templating,
         Session $pomm,
         Serializer $serializer,
-        PropertyInfoExtractor $property,
+        PropertyInfoExtractorInterface $property,
         Session $serviceSession,
         ServiceModel $serviceModel
     ) {


### PR DESCRIPTION
Since PHP 7.3.7 missing interfaces throws exceptions

=> https://www.php.net/ChangeLog-7.php#7.3.7

`EntityParamConverter.php` use `Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface` but Sensio framework extra bundle is not a requirement in `composer.json`.

If project require `pomm-project/pomm-bundle` but not `sensio/framework-extra-bundle`, we get a uncaught fatal error on each request/cli command