### PR TITLE
Fix deprecated notice in DependencyInjection for Symfony 4

### DIFF
--- a/sources/lib/DependencyInjection/Configuration.php
+++ b/sources/lib/DependencyInjection/Configuration.php
@@ -32,8 +32,15 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('pomm');
+        $treeBuilder = new TreeBuilder('pomm');
+
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('pomm');
+        }
+
         $rootNode
             ->children()
                 ->arrayNode('configuration')


### PR DESCRIPTION
Remove a deprecated in DependencyInjection for Symfony 4.

The existing PR #107 is not active so there is a new one with BC layer. 