### PR TITLE
Remove forgotten service deprecated in 2.x (fix #112)

### DIFF
--- a/sources/lib/Resources/config/services/pomm.yml
+++ b/sources/lib/Resources/config/services/pomm.yml
@@ -36,13 +36,6 @@ services:
         tags:
             - { name: "property_info.type_extractor" }
         public: true
-    # @deprecated
-    pomm.property_info:
-        class: 'PommProject\SymfonyBridge\PropertyInfo\Extractor\PommExtractor'
-        arguments: ['@pomm']
-        tags:
-            - { name: "property_info.type_extractor" }
-        public: true
     pomm.session_builder:
         class: 'PommProject\Foundation\SessionBuilder'
     pomm.model_manager.session_builder:


### PR DESCRIPTION
A class from Symfony Bridge, PommExtractor, is deprecated since version 2.3 and should have been removed in 3.0.
It's still called in services.

Removing the call here.

A PR is coming for Symfony Bridge