### PR TITLE
Add NotFoundHttpException in EntityParamConverter

### DIFF
--- a/sources/lib/Request/ParamConverter/EntityParamConverter.php
+++ b/sources/lib/Request/ParamConverter/EntityParamConverter.php
@@ -7,6 +7,7 @@ use PommProject\ModelManager\Model\Model;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class EntityParamConverter implements ParamConverterInterface
 {
@@ -47,6 +48,16 @@ class EntityParamConverter implements ParamConverterInterface
             }
         }
 
+        if (null === $entity && false === $options["optional"]) {
+            throw new NotFoundHttpException(
+                sprintf(
+                    '%s object not found by the %s.',
+                    $options['model'],
+                    $this->getClassName($this)
+                )
+            );
+        }
+
         $request->attributes->set($name, $entity);
 
         return true;
@@ -82,5 +93,12 @@ class EntityParamConverter implements ParamConverterInterface
             $values[$key] = $request->attributes->get($key);
         }
         return $values;
+    }
+
+    private function getClassName(ParamConverterInterface $configuration)
+    {
+        $r = new \ReflectionClass($configuration);
+
+        return $r->getName();
     }
 }


### PR DESCRIPTION
In ParamConverter, if an object is not found, a 404 Response is generated.

Reference : https://symfony.com/bundles/SensioFrameworkExtraBundle/current/annotations/converters.html

> If no Post object is found, a 404 Response is generated;